### PR TITLE
Support cli parameters (#186)

### DIFF
--- a/e2e/scripts/disconnect.py
+++ b/e2e/scripts/disconnect.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/e2e/scripts/magic.py
+++ b/e2e/scripts/magic.py
@@ -76,8 +76,10 @@ try:
 finally:
     "FINALLY"
 
+
 def func(value):
     value
+
 
 func("FUNCTION")
 
@@ -116,8 +118,10 @@ async_loop.run_until_complete(async_with())
 
 # Docstrings should never be printed
 
+
 def docstrings():
     """Docstring. Should not be printed."""
+
     def nested():
         """Multiline docstring.
         Should not be printed."""
@@ -125,8 +129,10 @@ def docstrings():
 
     class Foo(object):
         """Class docstring. Should not be printed."""
+
         pass
 
     nested()
+
 
 docstrings()

--- a/e2e/scripts/message_deduping.py
+++ b/e2e/scripts/message_deduping.py
@@ -20,4 +20,4 @@ import streamlit as st
 df = list(range(100000))
 st.dataframe(df)
 st.dataframe(df)
-st.write('hello!')
+st.write("hello!")

--- a/e2e/scripts/reuse_label.py
+++ b/e2e/scripts/reuse_label.py
@@ -15,7 +15,7 @@
 
 import streamlit as st
 
-if st.button('Rerun test'):
+if st.button("Rerun test"):
     st.test_run_count = -1
 
 if hasattr(st, "test_run_count"):
@@ -30,8 +30,10 @@ else:
 
 st.write("value 1:", w1)
 st.write("test_run_count:", st.test_run_count)
-st.write("""
+st.write(
+    """
     If this is failing locally, it could be because you have a browser with
     Streamlit open. Close it and the test should pass.
-""")
+"""
+)
 # TODO: Use session-specific state for test_run_count, to fix the issue above.

--- a/e2e/scripts/st_in_cache_warning.py
+++ b/e2e/scripts/st_in_cache_warning.py
@@ -35,7 +35,9 @@ cached_write("I'm in a cached function!")
 cached_widget("Wadjet!")
 cached_write_nowarn("Me too!")
 
-st.write("""
+st.write(
+    """
     If this is failing locally, it could be because you have a browser with
     Streamlit open. Close it and the test should pass.
-""")
+"""
+)

--- a/frontend/src/components/core/ReportView/Widget.scss
+++ b/frontend/src/components/core/ReportView/Widget.scss
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-@import 'assets/css/variables';
-
+@import "assets/css/variables";
 
 .Widget > label {
   font-size: $font-size-sm;

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,12 +19,15 @@ requirements = convert_deps_to_pip(packages, r=False)
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
-if (platform.system() == 'Darwin' and
-        subprocess.call(['xcode-select', '--version'], shell=False) != 0):
+if (
+    platform.system() == "Darwin"
+    and subprocess.call(["xcode-select", "--version"], shell=False) != 0
+):
     try:
-        requirements.remove('watchdog')
+        requirements.remove("watchdog")
     except ValueError:
         pass
+
 
 def readme():
     with open("README.md") as f:

--- a/lib/streamlit/ConfigOption.py
+++ b/lib/streamlit/ConfigOption.py
@@ -99,6 +99,7 @@ class ConfigOption(object):
         expiration_date=None,
         replaced_by=None,
         config_getter=None,
+        type_=str,
     ):
         """Create a ConfigOption with the given name.
 
@@ -129,6 +130,8 @@ class ConfigOption(object):
         config_getter : callable or None
             Required if replaced_by != None. Should be set to
             config.get_option.
+        type_ : one of str, int, float or bool
+            Useful to cast the config params sent by cmd option parameter.
         """
         # Parse out the section and name.
         self.key = key
@@ -145,6 +148,7 @@ class ConfigOption(object):
         self.replaced_by = replaced_by
         self._get_val_func = None
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
+        self.type = type_
 
         if self.replaced_by:
             self.deprecated = True

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -118,8 +118,7 @@ def _with_element(method):
         def marshall_element(element):
             return method(dg, element, *args, **kwargs)
 
-        return dg._enqueue_new_element_delta(
-            marshall_element, delta_type, last_index)
+        return dg._enqueue_new_element_delta(marshall_element, delta_type, last_index)
 
     return wrapped_method
 
@@ -168,7 +167,7 @@ def _get_widget_ui_value(widget_type, element):
 
 def _get_pandas_index_attr(data, attr):
     python3_attr = getattr(data.index, attr, None)
-    python2_attr = getattr(data.index, '__dict__', None)
+    python2_attr = getattr(data.index, "__dict__", None)
 
     if python3_attr:
         return python3_attr
@@ -1464,15 +1463,18 @@ class DeltaGenerator(object):
             for value in default_values:
                 if not isinstance(value, string_types):  # noqa: F821
                     raise TypeError(
-                        "A Multiselect default value has invalid type: %s" % type(
-                            value).__name__
+                        "A Multiselect default value has invalid type: %s"
+                        % type(value).__name__
                     )
                 if value not in options:
                     raise ValueError(
-                        "Every Multiselect default value must exist in options")
+                        "Every Multiselect default value must exist in options"
+                    )
             return [options.index(value) for value in default]
 
-        indices = _check_and_convert_to_indices(default) if default is not None else None
+        indices = (
+            _check_and_convert_to_indices(default) if default is not None else None
+        )
         element.multiselect.label = label
         default_value = [] if indices is None else indices
         element.multiselect.default[:] = default_value
@@ -2224,7 +2226,8 @@ class DeltaGenerator(object):
             )
 
         data, self._last_index = _maybe_melt_data_for_add_rows(
-            data, self._delta_type, self._last_index)
+            data, self._delta_type, self._last_index
+        )
 
         msg = ForwardMsg_pb2.ForwardMsg()
         msg.metadata.parent_block.container = self._container
@@ -2232,6 +2235,7 @@ class DeltaGenerator(object):
         msg.metadata.delta_id = self._id
 
         import streamlit.elements.data_frame_proto as data_frame_proto
+
         data_frame_proto.marshall_data_frame(data, msg.delta.add_rows.data)
 
         if name:
@@ -2255,16 +2259,15 @@ def _maybe_melt_data_for_add_rows(data, delta_type, last_index):
             data = data_frame_proto.convert_anything_to_df(data)
 
         if type(data.index) is pd.RangeIndex:
-            old_step = _get_pandas_index_attr(data, 'step')
+            old_step = _get_pandas_index_attr(data, "step")
 
             # We have to drop the predefined index
             data = data.reset_index(drop=True)
 
-            old_stop = _get_pandas_index_attr(data, 'stop')
+            old_stop = _get_pandas_index_attr(data, "stop")
 
             if old_step is None or old_stop is None:
-                raise AttributeError("'RangeIndex' object has no attribute "
-                                     "'step'")
+                raise AttributeError("'RangeIndex' object has no attribute " "'step'")
 
             start = last_index + old_step
             stop = last_index + old_step + old_stop
@@ -2275,6 +2278,7 @@ def _maybe_melt_data_for_add_rows(data, delta_type, last_index):
         data = pd.melt(data.reset_index(), id_vars=["index"])
 
     return data, last_index
+
 
 def _clean_text(text):
     return textwrap.dedent(str(text)).strip()

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -213,7 +213,8 @@ def _build_caching_func_error_message(persisted, func, caller_frame):
     else:
         load_or_rerun = "rerunning the function"
 
-    message = textwrap.dedent("""
+    message = textwrap.dedent(
+        """
         **Your code mutated a cached return value**
 
         Streamlit detected the mutation of a return value of `{name}`, which is
@@ -267,7 +268,8 @@ def _build_caching_block_error_message(persisted, code, line_number_range):
     else:
         lines = "lines {start} to {end}".format(start=start, end=end)
 
-    message = textwrap.dedent("""
+    message = textwrap.dedent(
+        """
         **Your code mutated a cached value**
 
         Streamlit detected the mutation of a cached value in `{file_name}` in
@@ -286,7 +288,8 @@ def _build_caching_block_error_message(persisted, code, line_number_range):
 
         Learn more about caching and copying in the [Streamlit documentation]
         (https://streamlit.io/docs/tutorial/create_a_data_explorer_app.html).
-    """).strip("\n")
+    """
+    ).strip("\n")
 
     return message.format(
         load_or_rerun=load_or_rerun,
@@ -297,7 +300,8 @@ def _build_caching_block_error_message(persisted, code, line_number_range):
 
 
 def _build_args_mutated_message(func):
-    message = textwrap.dedent("""
+    message = textwrap.dedent(
+        """
         **Cached function mutated its input arguments**
 
         When decorating a function with `@st.cache`, the arguments should not
@@ -307,7 +311,8 @@ def _build_args_mutated_message(func):
         See the [Streamlit
         docs](https://streamlit.io/docs/tutorial/create_a_data_explorer_app.html) for more
         info.
-    """).strip("\n")
+    """
+    ).strip("\n")
 
     return message.format(name=func.__name__)
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -23,6 +23,8 @@ from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
+from streamlit import config as _config
+
 import os
 import click
 
@@ -118,16 +120,70 @@ def main_hello():
     _main_run(filename)
 
 
+def _convert_config_option_to_click_option(config_option):
+    """Composes given config option options as options for click lib."""
+    option = "--{}".format(config_option.key)
+    param = config_option.key.replace(".", "_")
+    description = config_option.description
+    if config_option.deprecated:
+        description += "\n {} - {}".format(
+            config_option.deprecation_text, config_option.deprecation_date
+        )
+
+    return {
+        "param": param,
+        "description": description,
+        "type": config_option.type,
+        "option": option,
+    }
+
+
+def configurator_options(func):
+    """Decorator that adds config param keys to click dynamically."""
+    for _, value in reversed(_config._config_options.items()):
+        parsed_parameter = _convert_config_option_to_click_option(value)
+        config_option = click.option(
+            parsed_parameter["option"],
+            parsed_parameter["param"],
+            help=parsed_parameter["description"],
+            type=parsed_parameter["type"],
+        )
+        func = config_option(func)
+    return func
+
+
+def _apply_config_options_from_cli(kwargs):
+    """The "streamlit run" command supports passing Streamlit's config options
+    as flags.
+
+    This function reads through all config flags, massage them, and
+    pass them to _set_config() overriding default values and values set via
+    config.toml file
+
+    """
+    for config_option in kwargs:
+        if kwargs[config_option] is not None:
+            config_option_def_key = config_option.replace("_", ".")
+
+            _config._set_option(
+                config_option_def_key, kwargs[config_option], "cli call option"
+            )
+
+
 @main.command("run")
+@configurator_options
 @click.argument("file_or_url", required=True)
 @click.argument("args", nargs=-1)
-def main_run(file_or_url, args=None):
+def main_run(file_or_url, args=None, **kwargs):
     """Run a Python script, piping stderr to Streamlit.
-    The script can be local or it can be an url. In the
-    latter case, streamlit will download the script to a
-    temporary file and runs this file.
+
+    The script can be local or it can be an url. In the latter case, Streamlit
+    will download the script to a temporary file and runs this file.
+
     """
     from validators import url
+
+    _apply_config_options_from_cli(kwargs)
 
     if url(file_or_url):
         import tempfile
@@ -233,9 +289,7 @@ def config():
 @config.command("show")
 def config_show():
     """Show all of Streamlit's config settings."""
-    from streamlit import config
-
-    config.show_config()
+    _config.show_config()
 
 
 # SUBCOMMAND: activate

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -48,8 +48,9 @@ _section_descriptions = collections.OrderedDict(
     _test="Special test section just used for unit tests."
 )
 
-# Stores the config options as key value pairs in a flat dict.
-_config_options = dict()
+# Stores the config options as key value pairs in an ordered dict to be able
+# to show the config params help in the same order they were included.
+_config_options = collections.OrderedDict()
 
 # Makes sure we only parse the config file once.
 config_file_has_been_parsed = False
@@ -114,6 +115,7 @@ def _create_option(
     deprecation_text=None,
     expiration_date=None,
     replaced_by=None,
+    type_=str,
 ):
     '''Create a ConfigOption and store it globally in this module.
 
@@ -159,6 +161,7 @@ def _create_option(
         deprecation_text=deprecation_text,
         expiration_date=expiration_date,
         replaced_by=replaced_by,
+        type_=type_,
     )
     assert option.section in _section_descriptions, (
         'Section "%s" must be one of %s.'
@@ -196,6 +199,7 @@ _create_option(
         If you'd like to turn off this warning, set this to True.
         """,
     default_val=False,
+    type_=bool,
 )
 
 
@@ -220,10 +224,11 @@ _create_option(
         via "python my_script.py".
         """,
     default_val=True,
+    type_=bool,
 )
 
 
-@_create_option("global.developmentMode", visibility="hidden")
+@_create_option("global.developmentMode", visibility="hidden", type_=bool)
 def _global_development_mode():
     """Are we in development mode.
 
@@ -249,7 +254,7 @@ def _global_log_level():
         return "info"
 
 
-@_create_option("global.unitTest", visibility="hidden")
+@_create_option("global.unitTest", visibility="hidden", type_=bool)
 def _global_unit_test():
     """Are we in a unit test?
 
@@ -264,6 +269,7 @@ _create_option(
         developmentMode is True.""",
     visibility="hidden",
     default_val=True,
+    type_=bool,
 )
 
 
@@ -272,6 +278,7 @@ _create_option(
     description="Whether to serve prometheus metrics from /metrics.",
     visibility="hidden",
     default_val=False,
+    type_=bool,
 )
 
 
@@ -281,6 +288,7 @@ _create_option(
         this minimum.""",
     visibility="hidden",
     default_val=10 * 1e3,
+    type_=int,
 )  # 10k
 
 
@@ -291,6 +299,7 @@ _create_option(
         finished running since the message has been accessed.""",
     visibility="hidden",
     default_val=2,
+    type_=int,
 )
 
 
@@ -299,7 +308,10 @@ _create_option(
 _create_section("client", "Settings for scripts that use Streamlit.")
 
 _create_option(
-    "client.caching", description="Whether to enable st.cache.", default_val=True
+    "client.caching",
+    description="Whether to enable st.cache.",
+    default_val=True,
+    type_=bool,
 )
 
 _create_option(
@@ -307,6 +319,7 @@ _create_option(
     description="""If false, makes your Streamlit script not draw to a
         Streamlit app.""",
     default_val=True,
+    type_=bool,
 )
 
 
@@ -321,6 +334,7 @@ _create_option(
         Python code to write it to the app.
         """,
     default_val=True,
+    type_=bool,
 )
 
 _create_option(
@@ -331,6 +345,7 @@ _create_option(
         script's execution.
         """,
     default_val=False,
+    type_=bool,
 )
 
 _create_option(
@@ -340,6 +355,7 @@ _create_option(
         prevent Python crashing.
         """,
     default_val=True,
+    type_=bool,
 )
 
 # Config Section: Server #
@@ -358,7 +374,7 @@ _create_option(
 )
 
 
-@_create_option("server.headless")
+@_create_option("server.headless", type_=bool)
 @util.memoize
 def _server_headless():
     """If false, will attempt to open a browser window on start.
@@ -377,7 +393,7 @@ def _server_headless():
     )
 
 
-@_create_option("server.liveSave")
+@_create_option("server.liveSave", type_=bool)
 def _server_live_save():
     """Immediately share the app in such a way that enables live
     monitoring, and post-run analysis.
@@ -387,7 +403,7 @@ def _server_live_save():
     return False
 
 
-@_create_option("server.runOnSave")
+@_create_option("server.runOnSave", type_=bool)
 def _server_run_on_save():
     """Automatically rerun script when the file is modified on disk.
 
@@ -396,7 +412,7 @@ def _server_run_on_save():
     return False
 
 
-@_create_option("server.port")
+@_create_option("server.port", type_=int)
 def _server_port():
     """The port where the server will listen for client and browser
     connections.
@@ -406,7 +422,7 @@ def _server_port():
     return 8501
 
 
-@_create_option("server.enableCORS")
+@_create_option("server.enableCORS", type_=bool)
 def _server_enable_cors():
     """Enables support for Cross-Origin Request Sharing, for added security.
 
@@ -430,7 +446,7 @@ def _browser_server_address():
     return "localhost"
 
 
-@_create_option("browser.gatherUsageStats")
+@_create_option("browser.gatherUsageStats", type_=bool)
 def _gather_usage_stats():
     """Whether to send usage statistics to Streamlit.
 
@@ -439,7 +455,7 @@ def _gather_usage_stats():
     return True
 
 
-@_create_option("browser.serverPort")
+@_create_option("browser.serverPort", type_=int)
 @util.memoize
 def _browser_server_port():
     """Port that the browser should use to connect to the server when in
@@ -502,6 +518,7 @@ _create_option(
         us at support@streamlit.io.
         """,
     default_val=False,
+    type_=bool,
 )
 
 _create_option(

--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/streamlit/elements/altair.py
+++ b/lib/streamlit/elements/altair.py
@@ -35,19 +35,24 @@ def generate_chart(chart_type, data):
         data = convert_anything_to_df(data)
 
     n_cols = len(data.columns)
-    data = pd.melt(data.reset_index(), id_vars=['index'])
+    data = pd.melt(data.reset_index(), id_vars=["index"])
 
-    if chart_type == 'area':
-        opacity = {'value': 0.7}
+    if chart_type == "area":
+        opacity = {"value": 0.7}
     else:
-        opacity = {'value': 1.0}
+        opacity = {"value": 1.0}
 
-    chart = getattr(alt.Chart(data), 'mark_' + chart_type)().encode(
-        alt.X('index', title=''),
-        alt.Y('value', title=''),
-        alt.Color('variable', title='', type='nominal'),
-        alt.Tooltip(['index', 'value', 'variable']),
-        opacity=opacity).interactive()
+    chart = (
+        getattr(alt.Chart(data), "mark_" + chart_type)()
+        .encode(
+            alt.X("index", title=""),
+            alt.Y("value", title=""),
+            alt.Color("variable", title="", type="nominal"),
+            alt.Tooltip(["index", "value", "variable"]),
+            opacity=opacity,
+        )
+        .interactive()
+    )
     return chart
 
 

--- a/lib/streamlit/elements/lib/__init__.py
+++ b/lib/streamlit/elements/lib/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class NoStaticFiles(Exception):
     pass
 

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -144,7 +144,8 @@ def _key(obj, context):
 
 
 def _hashing_error_message(start):
-    return textwrap.dedent("""
+    return textwrap.dedent(
+        """
         %(start)s,
 
         **More information:** to prevent unexpected behavior, Streamlit tries
@@ -156,7 +157,9 @@ def _hashing_error_message(start):
         To stop this warning from showing in the meantime, try one of the following:
         * **Preferred:** modify your code to avoid using this type of object.
         * Or add the argument `ignore_hash=True` to the `st.cache` decorator.
-    """ % {'start': start}).strip("\n")
+    """
+        % {"start": start}
+    ).strip("\n")
 
 
 class CodeHasher:
@@ -343,13 +346,13 @@ class CodeHasher:
                     st.warning(
                         _hashing_error_message(
                             "Streamlit cannot hash an object of type %s." % type(obj)
-                        ),
+                        )
                     )
         except:
             st.warning(
                 _hashing_error_message(
                     "Streamlit failed to hash an object of type %s." % type(obj)
-                ),
+                )
             )
 
     def _code_to_bytes(self, code, context):

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -30,7 +30,8 @@ LOGGER = get_logger(__name__)
 def intro():
     st.sidebar.success("Select a demo above.")
 
-    st.markdown("""
+    st.markdown(
+        """
         Streamlit is an open-source app framework built specifically for
         Machine Learning and Data Science projects.
 
@@ -50,7 +51,8 @@ def intro():
           Dataset] (https://github.com/streamlit/demo-self-driving)
         - Explore a [New York City rideshare dataset]
           (https://github.com/streamlit/demo-uber-nyc-pickups)
-    """)
+    """
+    )
 
 
 # Turn off black formatting for this function to present the user with more

--- a/lib/streamlit/server/__init__.py
+++ b/lib/streamlit/server/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/streamlit/storage/__init__.py
+++ b/lib/streamlit/storage/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/streamlit/watcher/__init__.py
+++ b/lib/streamlit/watcher/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/tests/__init__.py
+++ b/lib/tests/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/tests/streamlit/add_rows_test.py
+++ b/lib/tests/streamlit/add_rows_test.py
@@ -79,12 +79,10 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             el = delta(DATAFRAME)
             el.add_rows(NEW_ROWS)
 
-            df_proto = data_frame_proto._get_data_frame(
-                        self.get_delta_from_queue())
+            df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
             num_rows = len(df_proto.data.cols[0].int64s.data)
 
             self.assertEqual(num_rows, 10)
-
 
     def test_simple_add_rows(self):
         """Test plain old add_rows."""

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -19,12 +19,16 @@ import unittest
 
 import requests
 import requests_mock
+import mock
 from click.testing import CliRunner
 from mock import patch, MagicMock
 import click
 
 import streamlit
 from streamlit import cli
+from streamlit.cli import _convert_config_option_to_click_option
+from streamlit.cli import _apply_config_options_from_cli
+from streamlit.ConfigOption import ConfigOption
 
 
 class CliTest(unittest.TestCase):
@@ -130,3 +134,44 @@ class CliTest(unittest.TestCase):
 
             cli._main_run("/not/a/file", None)
             self.assertTrue(streamlit._is_running_with_streamlit)
+
+    def test_convert_config_option_to_click_option(self):
+        """Test that configurator_options adds dynamic commands based on a
+        config lists.
+        """
+        config_option = ConfigOption(
+            "server.customKey",
+            description="Custom description.\n\nLine one.",
+            deprecated=False,
+            type_=int,
+        )
+
+        result = _convert_config_option_to_click_option(config_option)
+
+        self.assertEqual(result["option"], "--server.customKey")
+        self.assertEqual(result["param"], "server_customKey")
+        self.assertEqual(result["type"], config_option.type)
+        self.assertEqual(result["description"], config_option.description)
+
+    @patch("streamlit.cli._config._set_option")
+    def test_apply_config_options_from_cli(self, patched__set_option):
+        """Test that _apply_config_options_from_cli parses the key properly and
+        passes down the parameters
+        """
+
+        kwargs = {
+            "server_port": 3005,
+            "server_headless": True,
+            "browser_serverAddress": "localhost",
+            "global_minCachedMessageSize": None,
+        }
+
+        _apply_config_options_from_cli(kwargs)
+
+        patched__set_option.assert_has_calls(
+            [
+                mock.call("server.port", 3005, "cli call option"),
+                mock.call("server.headless", True, "cli call option"),
+                mock.call("browser.serverAddress", "localhost", "cli call option"),
+            ], any_order=True
+        )

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -85,10 +85,9 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertListEqual(c.default[:], [])
         self.assertEqual(c.options, [])
 
-    @parameterized.expand([(None, []), ([], []),
-                           (["Tea", "Water"], [1, 2]),
-                           (("Tea", "Water"), [1, 2]),
-                           ])
+    @parameterized.expand(
+        [(None, []), ([], []), (["Tea", "Water"], [1, 2]), (("Tea", "Water"), [1, 2])]
+    )
     def test_defaults(self, defaults, expected):
         """Test that valid default can be passed as expected."""
         st.multiselect("the label", ["Coffee", "Tea", "Water"], defaults)

--- a/lib/tests/streamlit/scriptrunner/__init__.py
+++ b/lib/tests/streamlit/scriptrunner/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/tests/streamlit/watcher/test_data/__init__.py
+++ b/lib/tests/streamlit/watcher/test_data/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/tests/streamlit/watcher/test_data/dummy_module1.py
+++ b/lib/tests/streamlit/watcher/test_data/dummy_module1.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/lib/tests/streamlit/watcher/test_data/dummy_module2.py
+++ b/lib/tests/streamlit/watcher/test_data/dummy_module2.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-


### PR DESCRIPTION
* add all existing config options as click cmd param options

* add description and deprecation notice to config param options

* adds type to ConfigOptions to properly type cast the cmd option params

* lint

* lint

* display config option keys --help in the same order they were created

* adds test to compose_option_parameter for cli cmd config options

* lint

* lint

* moved logic to parse config options out of main_run

* lint

* fix tests for cli config option params on py2.7

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
