### PR TITLE
Handle lack of trailing slash (#528)

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -37,6 +37,7 @@ from streamlit.ReportSession import ReportSession
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.server.routes import AddSlashHandler
 from streamlit.server.routes import DebugHandler
 from streamlit.server.routes import HealthHandler
 from streamlit.server.routes import MessageCacheHandler
@@ -263,6 +264,10 @@ class Server(object):
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
                         {"path": "%s/" % static_path, "default_filename": "index.html"},
+                    ),
+                    (
+                        make_url_path_regex(base, trailing_slash=False),
+                        AddSlashHandler
                     )
                 ]
             )

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -53,6 +53,12 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             self.set_header("Cache-Control", "public")
 
 
+class AddSlashHandler(tornado.web.RequestHandler):
+    @tornado.web.addslash
+    def get(self):
+        pass
+
+
 class _SpecialRequestHandler(tornado.web.RequestHandler):
     """Superclass for "special" endpoints, like /healthz."""
 

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -147,7 +147,8 @@ def _get_s3_url_host_if_manually_set():
         return util.get_hostname(config.get_option("s3.url"))
 
 
-def make_url_path_regex(*path):
+def make_url_path_regex(*path, **kwargs):
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x.strip("/") for x in path if x]  # Filter out falsy components.
-    return r"^/%s/?$" % "/".join(path)
+    path_format = r"^/%s/?$" if kwargs.get("trailing_slash", True) else r"^/%s$"
+    return path_format % "/".join(path)

--- a/lib/tests/streamlit/Report_test.py
+++ b/lib/tests/streamlit/Report_test.py
@@ -118,6 +118,7 @@ class ReportTest(unittest.TestCase):
             (None, None, "http://the_ip_address:8501"),
             (None, 9988, "http://the_ip_address:9988"),
             ("foo", None, "http://the_ip_address:8501/foo"),
+            ("foo/", None, "http://the_ip_address:8501/foo"),
             ("/foo/bar/", None, "http://the_ip_address:8501/foo/bar"),
             ("/foo/bar/", 9988, "http://the_ip_address:9988/foo/bar"),
         ]


### PR DESCRIPTION
* Make the trailing slash optional

Add a kw-arg to make_url_path_regex that controls whether an optional
trailing slash is included at the end of the path pattern. This will be
used to generate a path without the trailing slash for redirects.

* Create a handler that adds a slash

Create a simple request handler that simply uses the
tornado.web.addslash decorator to add a slash to the end of the request
path for GET requests.

* Redirect to base path with slash

If a request comes in for the app on the base path without a trailing
slash, respond with a redirect to the path with the trailing slash.
Otherwise, users just receive a 404 Not Found.

* Add test case for trailing slash

Add an extra test case ensuring that trailing slashes are removed.

* Gather keyword args

Python 2.7 doesn’t support having keyword args after an args collector.
Replacing trailing_slash with gathering all keyword args, and then
extract it from there.

## Before contributing

**As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
