### PR TITLE
Nicer frontend exception display (#490)

### DIFF
--- a/frontend/src/components/elements/ExceptionElement/ExceptionElement.scss
+++ b/frontend/src/components/elements/ExceptionElement/ExceptionElement.scss
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
+@import "src/assets/css/variables";
+
 .reportview-container {
-  .exception .message {
-    margin-bottom: 0.5rem;
+  .exception .message .type {
+    font-weight: bold;
   }
 
-  .exception .stack-trace {
+  .exception .stack-trace-row {
+    margin-top: 0.5rem;
+  }
+
+  .exception .stack-trace-title {
     font-family: "IBM Plex Mono", monospace;
     font-size: 0.8rem;
-    margin-left: 1rem;
-    margin-right: 1rem;
-  }
-
-  .exception .stack-trace .row {
     margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 }

--- a/frontend/src/components/elements/ExceptionElement/ExceptionElement.tsx
+++ b/frontend/src/components/elements/ExceptionElement/ExceptionElement.tsx
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import React from "react"
+import { StreamlitMarkdown } from "components/shared/StreamlitMarkdown"
 import { Map as ImmutableMap } from "immutable"
+import React, { ReactNode } from "react"
 import "./ExceptionElement.scss"
 
 interface Props {
@@ -31,29 +32,55 @@ class ExceptionElement extends React.PureComponent<Props> {
   public render(): React.ReactNode {
     const { element, width } = this.props
     const type = element.get("type")
-    let message = element.get("message")
-    if (message) {
-      message = `: ${message}`
-    }
+    const message = element.get("message")
     const stackTrace = element.get("stackTrace")
 
-    // Put it all together into a nice little html view.
+    // Build the message display.
+    // On the backend, we use the StreamlitException type for errors that
+    // originate from inside Streamlit. These errors have Markdown-formatted
+    // messages, and so we wrap those messages inside our Markdown renderer.
+    let messageNode: ReactNode
+    if (element.get("messageIsMarkdown")) {
+      let markdown = `**${type}**`
+      if (message) {
+        markdown += `: ${message}`
+      }
+      messageNode = <StreamlitMarkdown source={markdown} allowHTML={false} />
+    } else {
+      messageNode = (
+        <>
+          <span className="type">{type}</span>
+          {message != null ? `: ${message}` : null}
+        </>
+      )
+    }
+
+    // Build the stack trace display, if we got a stack trace.
+    let stackTraceNode: ReactNode = null
+    if (stackTrace && stackTrace.size > 0) {
+      stackTraceNode = (
+        <>
+          <div className="stack-trace-title">Traceback:</div>
+          <pre>
+            <code>
+              {stackTrace.map((row: string, indx: string) => (
+                <div className="stack-trace-row" key={indx}>
+                  {row}
+                </div>
+              ))}
+            </code>
+          </pre>
+        </>
+      )
+    }
+
     return (
       <div
         className="alert alert-danger exception stException"
         style={{ width }}
       >
-        <div className="message">
-          <strong>{type}</strong>
-          {message}
-        </div>
-        <div className="stack-trace">
-          {stackTrace.map((row: string, indx: string) => (
-            <div className="row" key={indx}>
-              {row}
-            </div>
-          ))}
-        </div>
+        <div className="message">{messageNode}</div>
+        {stackTraceNode}
       </div>
     )
   }

--- a/frontend/src/components/shared/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown.tsx
@@ -1,0 +1,93 @@
+import CodeBlock from "components/elements/CodeBlock"
+import React, { ReactElement, ReactNode } from "react"
+import ReactMarkdown from "react-markdown"
+
+// @ts-ignore
+import htmlParser from "react-markdown/plugins/html-parser"
+// @ts-ignore
+import { InlineMath, BlockMath } from "react-katex"
+// @ts-ignore
+import RemarkMathPlugin from "remark-math"
+
+import "katex/dist/katex.min.css"
+
+export interface Props {
+  /**
+   * The Markdown formatted text to render.
+   */
+  source: string
+
+  /**
+   * True if HTML is allowed in the source string. If this is false,
+   * any HTML will be escaped in the output.
+   */
+  allowHTML: boolean
+}
+
+/**
+ * Wraps the <ReactMarkdown> component to include our standard
+ * renderers and AST plugins (for syntax hiliting, HTML support, etc).
+ */
+export class StreamlitMarkdown extends React.PureComponent<Props> {
+  public render(): ReactNode {
+    const renderers = {
+      code: CodeBlock,
+      link: linkWithTargetBlank,
+      linkReference: linkReferenceHasParens,
+      inlineMath: (props: { value: string }) => (
+        <InlineMath>{props.value}</InlineMath>
+      ),
+      math: (props: { value: string }) => <BlockMath>{props.value}</BlockMath>,
+    }
+
+    const plugins = [RemarkMathPlugin]
+
+    const astPlugins = this.props.allowHTML ? [htmlParser()] : []
+
+    return (
+      <ReactMarkdown
+        source={this.props.source}
+        escapeHtml={!this.props.allowHTML}
+        astPlugins={astPlugins}
+        plugins={plugins}
+        renderers={renderers}
+      />
+    )
+  }
+}
+
+interface LinkProps {
+  href: string
+  children: ReactElement
+}
+
+interface LinkReferenceProps {
+  href: string
+  children: [ReactElement]
+}
+
+// Using target="_blank" without rel="noopener noreferrer" is a security risk:
+// see https://mathiasbynens.github.io/rel-noopener
+function linkWithTargetBlank(props: LinkProps): ReactElement {
+  return (
+    <a href={props.href} target="_blank" rel="noopener noreferrer">
+      {props.children}
+    </a>
+  )
+}
+
+// Handle rendering a link through a reference, ex [text](href)
+// Don't convert to a link if only `[text]` and missing `(href)`
+function linkReferenceHasParens(props: LinkReferenceProps): any {
+  const { href, children } = props
+
+  if (!href) {
+    return children.length ? `[${children[0].props.children}]` : ""
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  )
+}

--- a/lib/streamlit/elements/exception_proto.py
+++ b/lib/streamlit/elements/exception_proto.py
@@ -13,12 +13,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import traceback
 
+import streamlit
+from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
+
+# Extract the streamlit package path
+_streamlit_dir = os.path.dirname(streamlit.__file__)
+# Make it absolute, and ensure there's a trailing path separator
+_streamlit_dir = os.path.join(os.path.realpath(_streamlit_dir), "")
+
+
+def marshall(exception_proto, exception, exception_traceback=None):
+    """Marshalls an Exception.proto message.
+
+    Parameters
+    ----------
+    exception_proto : Exception.proto
+        The Exception protobuf to fill out
+
+    exception : BaseException
+        The exception whose data we're extracting
+
+    exception_traceback : traceback or None
+        An optional alternate traceback to use. If this is None, the traceback
+        will be extracted from the exception.
+    """
+    exception_proto.type = type(exception).__name__
+
+    # If this is a StreamlitAPIException, we prune all Streamlit entries
+    # from the exception's stack trace.
+    is_api_exception = isinstance(exception, StreamlitAPIException)
+
+    stack_trace = _get_stack_trace(
+        exception, exception_traceback, strip_streamlit_stack_entries=is_api_exception
+    )
+
+    exception_proto.stack_trace.extend(stack_trace)
+
+    try:
+        if isinstance(exception, SyntaxError):
+            # SyntaxErrors have additional fields (filename, text, lineno,
+            # offset) that we can use for a nicely-formatted message telling
+            # the user what to fix.
+            exception_proto.message = _format_syntax_error_message(exception)
+        else:
+            exception_proto.message = str(exception)
+            exception_proto.message_is_markdown = is_api_exception
+    except Exception as str_exception:
+        # Sometimes the exception's __str__/__unicode__ method itself
+        # raises an error.
+        exception_proto.message = ""
+        LOGGER.warning(
+            """
+
+Streamlit was unable to parse the data from an exception in the user's script.
+This is usually due to a bug in the Exception object itself. Here is some info
+about that Exception object, so you can report a bug to the original author:
+
+Exception type:
+  %(etype)s
+
+Problem:
+  %(str_exception)s
+
+Traceback:
+%(str_exception_tb)s
+
+        """
+            % {
+                "etype": type(exception).__name__,
+                "str_exception": str_exception,
+                "str_exception_tb": "\n".join(_get_stack_trace(str_exception)),
+            }
+        )
 
 
 def _format_syntax_error_message(exception):
@@ -60,65 +133,46 @@ def _format_syntax_error_message(exception):
     return str(exception)
 
 
-def marshall(exception_proto, exception, exception_traceback=None):
-    """Marshalls an Exception.proto message.
+def _is_in_streamlit_package(file):
+    """True if the given file is part of the streamlit package."""
+    return (
+        os.path.commonprefix([os.path.realpath(file), _streamlit_dir]) == _streamlit_dir
+    )
+
+
+def _get_stackframe_filename(frame):
+    """Return the filename component of a traceback frame."""
+    # Python 3 has a frame.filename variable, but frames in
+    # Python 2 are just tuples. This code works in both versions.
+    return frame[0]
+
+
+def _get_stack_trace(
+    exception, exception_traceback=None, strip_streamlit_stack_entries=False
+):
+    """Get the stack trace for the given exception.
 
     Parameters
     ----------
-    exception_proto : Exception.proto
-        The Exception protobuf to fill out
-
     exception : BaseException
-        The exception whose data we're extracting
+        The exception to extract the traceback from
 
-    exception_traceback : Exception Traceback or None
-        If None or False, does not show display the trace. If True,
-        tries to capture a trace automatically. If a Traceback object,
-        displays the given traceback.
+    exception_traceback : traceback or None
+        An optional alternate traceback to use. If this is None, the traceback
+        will be extracted from the exception.
+
+    strip_streamlit_stack_entries : bool
+        If True, all traceback entries that are in the Streamlit package
+        will be removed from the list. We do this for exceptions that result
+        from incorrect usage of Streamlit APIs, so that the user doesn't see
+        a bunch of noise about ScriptRunner, DeltaGenerator, etc.
+
+    Returns
+    -------
+    list
+        The exception traceback as a list of strings
+
     """
-    exception_proto.type = type(exception).__name__
-
-    stack_trace = get_stack_trace(exception, exception_traceback)
-    exception_proto.stack_trace.extend(stack_trace)
-
-    try:
-        if isinstance(exception, SyntaxError):
-            # SyntaxErrors have additional fields (filename, text, lineno,
-            # offset) that we can use for a nicely-formatted message telling
-            # the user what to fix.
-            exception_proto.message = _format_syntax_error_message(exception)
-        else:
-            exception_proto.message = str(exception)
-    except Exception as str_exception:
-        # Sometimes the exception's __str__/__unicode__ method itself
-        # raises an error.
-        exception_proto.message = ""
-        LOGGER.warning(
-            """
-
-Streamlit was unable to parse the data from an exception in the user's script.
-This is usually due to a bug in the Exception object itself. Here is some info
-about that Exception object, so you can report a bug to the original author:
-
-Exception type:
-  %(etype)s
-
-Problem:
-  %(str_exception)s
-
-Traceback:
-%(str_exception_tb)s
-
-        """
-            % {
-                "etype": type(exception).__name__,
-                "str_exception": str_exception,
-                "str_exception_tb": "\n".join(get_stack_trace(str_exception)),
-            }
-        )
-
-
-def get_stack_trace(exception, exception_traceback=None):
     # Get and extract the traceback for the exception.
     if exception_traceback is not None:
         extracted_traceback = traceback.extract_tb(exception_traceback)
@@ -142,6 +196,12 @@ def get_stack_trace(exception, exception_traceback=None):
             "Try calling exception() within the `catch` block."
         ]
     else:
+        if strip_streamlit_stack_entries:
+            extracted_traceback = [
+                frame
+                for frame in extracted_traceback
+                if not _is_in_streamlit_package(_get_stackframe_filename(frame))
+            ]
         stack_trace = traceback.format_list(extracted_traceback)
 
     return stack_trace

--- a/lib/streamlit/elements/image_proto.py
+++ b/lib/streamlit/elements/image_proto.py
@@ -24,6 +24,8 @@ import numpy as np
 import six
 
 from PIL import Image, ImageFile
+
+from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from urllib.parse import urlparse
 
@@ -80,9 +82,9 @@ def _4d_to_list_3d(array):
 
 def _verify_np_shape(array):
     if len(array.shape) not in (2, 3):
-        raise RuntimeError("Numpy shape has to be of length 2 or 3.")
-    if len(array.shape) == 3:
-        assert array.shape[-1] in (1, 3, 4), (
+        raise StreamlitAPIException("Numpy shape has to be of length 2 or 3.")
+    if len(array.shape) == 3 and array.shape[-1] not in (1, 3, 4):
+        raise StreamlitAPIException(
             "Channel can only be 1, 3, or 4 got %d. Shape is %s"
             % (array.shape[-1], str(array.shape))
         )
@@ -201,7 +203,7 @@ def marshall_images(
                 if len(data.shape) == 3:
                     data = data[:, :, [2, 1, 0]]
                 else:
-                    raise RuntimeError(
+                    raise StreamlitAPIException(
                         'When using `channels="BGR"`, the input image should '
                         "have exactly 3 color channels"
                     )

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -22,5 +22,24 @@ class S3NoCredentials(Exception):
     pass
 
 
-class DuplicateWidgetID(Exception):
+class StreamlitAPIException(Exception):
+    """Base class for Streamlit API exceptions.
+
+    An API exception should be thrown when user code interacts with the
+    Streamlit API incorrectly. (That is, when we throw an exception as a
+    result of a user's malformed `st.foo` call, it should be a
+    StreamlitAPIException or subclass.)
+
+    Instances of this class can use markdown in their messages, which will get
+    nicely formatted on the frontend.
+
+    When displaying these exceptions on the frontend, we strip Streamlit
+    entries from the stack trace so that the user doesn't see a bunch of
+    noise related to Streamlit internals.
+    """
+
+    pass
+
+
+class DuplicateWidgetID(StreamlitAPIException):
     pass

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from streamlit.DeltaGenerator import _build_duplicate_widget_message
 from streamlit.compatibility import setup_2_3_shims
 from streamlit.errors import DuplicateWidgetID
+from streamlit.errors import StreamlitAPIException
 
 setup_2_3_shims(globals())
 
@@ -449,10 +450,10 @@ class DeltaGeneratorProgressTest(testutil.DeltaGeneratorTestCase):
         """Test Progress with bad values."""
         values = [-1, 101, -0.01, 1.01]
         for value in values:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(StreamlitAPIException):
                 st.progress(value)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(StreamlitAPIException):
             st.progress("some string")
 
 

--- a/lib/tests/streamlit/exception_proto_test.py
+++ b/lib/tests/streamlit/exception_proto_test.py
@@ -14,10 +14,15 @@
 # limitations under the License.
 
 """exception_proto Unittest."""
-
+import os
 import unittest
 
+import streamlit as st
+from streamlit import errors
+from streamlit.elements import exception_proto
 from streamlit.elements.exception_proto import _format_syntax_error_message
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
 
 
 class ExceptionProtoTest(unittest.TestCase):
@@ -34,3 +39,42 @@ File "syntax_hilite.py", line 84
 SyntaxError: invalid syntax
 """
         self.assertEqual(expected.strip(), _format_syntax_error_message(err))
+
+    def test_markdown_flag(self):
+        """Test that ExceptionProtos for StreamlitAPIExceptions (and
+        subclasses) have the "message_is_markdown" flag set.
+        """
+        proto = ExceptionProto()
+        exception_proto.marshall(proto, RuntimeError("oh no!"))
+        self.assertFalse(proto.message_is_markdown)
+
+        proto = ExceptionProto()
+        exception_proto.marshall(proto, StreamlitAPIException("oh no!"))
+        self.assertTrue(proto.message_is_markdown)
+
+        proto = ExceptionProto()
+        exception_proto.marshall(proto, errors.DuplicateWidgetID("oh no!"))
+        self.assertTrue(proto.message_is_markdown)
+
+    def test_strip_streamlit_stack_entries(self):
+        """Test that StreamlitAPIExceptions don't include Streamlit entries
+        in the stack trace.
+
+        """
+        # Create a StreamlitAPIException.
+        err = None
+        try:
+            st.image("http://not_an_image.png", width=-1)
+        except StreamlitAPIException as e:
+            err = e
+        self.assertIsNotNone(err)
+
+        # Marshall it.
+        proto = ExceptionProto()
+        exception_proto.marshall(proto, err)
+
+        # The streamlit package should not appear in any stack entry.
+        streamlit_dir = os.path.dirname(st.__file__)
+        streamlit_dir = os.path.join(os.path.realpath(streamlit_dir), "")
+        for line in proto.stack_trace:
+            self.assertNotIn(streamlit_dir, line, "Streamlit stack entry not stripped")

--- a/lib/tests/streamlit/image_proto_test.py
+++ b/lib/tests/streamlit/image_proto_test.py
@@ -18,6 +18,8 @@
 import pytest
 from PIL import Image, ImageDraw
 from parameterized import parameterized
+
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 import cv2
 import numpy as np
@@ -179,14 +181,17 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * check shape 3 but dims 1, 3, 4
         * if only one channel convert to just 2 dimensions.
         """
-        with pytest.raises(RuntimeError) as shape_exc:
+        with pytest.raises(StreamlitAPIException) as shape_exc:
             st.image(np.ndarray(shape=1))
-        assert "Numpy shape has to be of length 2 or 3." == str(shape_exc.value)
+        self.assertEqual(
+            "Numpy shape has to be of length 2 or 3.", str(shape_exc.value)
+        )
 
-        with pytest.raises(AssertionError) as shape2_exc:
+        with pytest.raises(StreamlitAPIException) as shape2_exc:
             st.image(np.ndarray(shape=(1, 2, 2)))
-        assert "Channel can only be 1, 3, or 4 got 2. Shape is (1, 2, 2)" == str(
-            shape2_exc.value
+        self.assertEqual(
+            "Channel can only be 1, 3, or 4 got 2. Shape is (1, 2, 2)",
+            str(shape2_exc.value),
         )
 
     def test_bytes_to_b64(self):

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -20,6 +20,7 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 
 
@@ -97,7 +98,9 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertListEqual(c.default[:], expected)
         self.assertEqual(c.options, ["Coffee", "Tea", "Water"])
 
-    @parameterized.expand([(["Tea", "Vodka"], ValueError), ([1, 2], TypeError)])
+    @parameterized.expand(
+        [(["Tea", "Vodka"], StreamlitAPIException), ([1, 2], StreamlitAPIException)]
+    )
     def test_invalid_defaults(self, defaults, expected):
         """Test that invalid default trigger the expected exception."""
         with self.assertRaises(expected):

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -20,6 +20,7 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 
 
@@ -95,10 +96,10 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
 
     def test_invalid_value(self):
         """Test that value must be an int."""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(StreamlitAPIException):
             st.radio("the label", ("m", "f"), "1")
 
     def test_invalid_value_range(self):
         """Test that value must be within the length of the options."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StreamlitAPIException):
             st.radio("the label", ("m", "f"), 2)

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -20,6 +20,7 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 
 
@@ -95,10 +96,10 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
 
     def test_invalid_value(self):
         """Test that value must be an int."""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(StreamlitAPIException):
             st.selectbox("the label", ("m", "f"), "1")
 
     def test_invalid_value_range(self):
         """Test that value must be within the length of the options."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StreamlitAPIException):
             st.selectbox("the label", ("m", "f"), 2)

--- a/lib/tests/streamlit/slider_test.py
+++ b/lib/tests/streamlit/slider_test.py
@@ -15,6 +15,7 @@
 
 """slider unit test."""
 
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 import streamlit as st
 from parameterized import parameterized
@@ -53,7 +54,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.default, proto_value)
 
     def test_value_greater_than_min(self):
-        with pytest.raises(ValueError) as exc_slider:
+        with pytest.raises(StreamlitAPIException) as exc_slider:
             st.slider("Slider label", 10, 100, 0)
         assert (
             "The default `value` of 0 must lie between the `min_value` of "
@@ -61,7 +62,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         )
 
     def test_value_smaller_than_max(self):
-        with pytest.raises(ValueError) as exc_slider:
+        with pytest.raises(StreamlitAPIException) as exc_slider:
             st.slider("Slider label", 10, 100, 101)
         assert (
             "The default `value` of 101 "
@@ -70,7 +71,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         )
 
     def test_max_min(self):
-        with pytest.raises(ValueError) as exc_slider:
+        with pytest.raises(StreamlitAPIException) as exc_slider:
             st.slider("Slider label", 101, 100, 101)
         assert (
             "The default `value` of 101 "

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 
 from streamlit import __version__
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Balloons_pb2 import Balloons
 from streamlit.proto.Text_pb2 import Text
 from tests import testutil
@@ -347,7 +348,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
     def test_st_image_bad_width(self):
         """Test st.image with bad width."""
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaises(StreamlitAPIException) as ctx:
             st.image("does/not/exist", width=-1234)
 
         self.assertTrue("Image width must be positive." in str(ctx.exception))

--- a/proto/streamlit/proto/Exception.proto
+++ b/proto/streamlit/proto/Exception.proto
@@ -23,8 +23,11 @@ message Exception {
   // Python exception type, like 'RuntimeError'.
   string type = 1;
 
-  // The exception's message:
+  // The exception's message.
   string message = 2;
+
+  // If true, the exception message should be rendered as Markdown text.
+  bool message_is_markdown = 4;
 
   // The stack trace to print.
   repeated string stack_trace = 3;


### PR DESCRIPTION
- Defines a new exception class, `StreamlitAPIException`, that's used for exceptions resulting from improper usage of the streamlit API. (That is, `StreamlitAPIException` is meant for "user errors", like calling a DeltaGenerator function with bad inputs.)
- `Exception.proto` has a new field, `message_is_markdown`, which is True when the exception being sent is a `StreamlitAPIException` instance. Markdown formatting in the exception message will be nicely rendered on the frontend.
- `StreamlitAPIException` stack traces get all Streamlit entries pruned before being marshalled into the exception proto. This means that when a user misuses a Streamlit API, they no longer see a bunch of ScriptRunner and DeltaGenerator lines in the stack trace we show them.
- I updated most (all?) user-facing errors to use StreamlitAPIException, for the nicer formatting.
- Non-API-related errors, originating from the bowels of Streamlit, will _not_ be specially pruned/formatted, so this shouldn't hinder us when debugging Streamlit itself.

Fixes #438

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
