### PR TITLE
@st.cache: do not support arbitrary keyword args.  (#915)

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -307,7 +307,7 @@ def cache(
     show_spinner=True,
     suppress_st_warning=False,
     hash_funcs=None,
-    **kwargs
+    ignore_hash=False,
 ):
     """Function decorator to memoize function executions.
 
@@ -340,6 +340,10 @@ def cache(
         inside Streamlit's caching mechanism: when the hasher encounters an object, it will first
         check to see if its type matches a key in this dict and, if so, will use the provided
         function to generate a hash for it. See below for an example of how this can be used.
+
+    ignore_hash : boolean
+        DEPRECATED. Please use allow_output_mutation instead.
+        This argument will be fully removed after 2020-03-16.
 
     Example
     -------
@@ -383,7 +387,7 @@ def cache(
     """
     # Help users migrate to the new kwarg
     # Remove this warning after 2020-03-16.
-    if "ignore_hash" in kwargs:
+    if ignore_hash:
         raise Exception(
             "The `ignore_hash` argument has been renamed to `allow_output_mutation`."
         )

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -115,8 +115,7 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
                 ds.signature,
                 (
                     "(func=None, persist=False, "
-                    "allow_output_mutation=False, show_spinner=True, suppress_st_warning=False, hash_funcs=None, "
-                    "**kwargs)"
+                    "allow_output_mutation=False, show_spinner=True, suppress_st_warning=False, hash_funcs=None, ignore_hash=False)"
                 ),
             )
             self.assertTrue(ds.doc_string.startswith("Function decorator to"))


### PR DESCRIPTION
* do not allow arbitrary kwargs in st.cache. ignore_hash named arg.

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
