### PR TITLE
Handle caching of dicts and custom objects (#869)

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -44,3 +44,7 @@ class StreamlitAPIException(Exception):
 
 class DuplicateWidgetID(StreamlitAPIException):
     pass
+
+
+class UnhashableType(StreamlitAPIException):
+    pass

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -34,8 +34,10 @@ import streamlit as st
 from streamlit import config
 from streamlit import file_util
 from streamlit import type_util
+from streamlit.errors import UnhashableType
 from streamlit.folder_black_list import FolderBlackList
 from streamlit.compatibility import setup_2_3_shims
+from streamlit.logger import get_logger
 
 if sys.version_info >= (3, 0):
     from streamlit.hashing_py3 import get_referenced_objects
@@ -50,6 +52,8 @@ try:
 except ImportError:
     import pickle
 
+
+LOGGER = get_logger(__name__)
 
 # If a dataframe has more than this many rows, we consider it large and hash a sample.
 PANDAS_ROWS_LARGE = 100000
@@ -187,39 +191,26 @@ def _key(obj, context):
     return None
 
 
-def _hashing_error_message(start):
+def _hashing_error_message(bad_type):
     return textwrap.dedent(
         """
-        %(start)s
+        Cannot hash object of type %(bad_type)s
 
-        **More information:** to prevent unexpected behavior, Streamlit tries
-        to detect mutations in cached objects defined in your local files so
-        it can alert you when the cache is used incorrectly. However, something
-        went wrong while performing this check.
+        While caching some code, Streamlit encountered an object of
+        type `%(bad_type)s`. You’ll need to help Streamlit understand how to
+        hash that type with the `hash_funcs` argument. For example:
 
-        This error can occur when your virtual environment lives in the same
-        folder as your project, since that makes it hard for Streamlit to
-        understand which files it should check. If you think that's what caused
-        this, please add the following to `~/.streamlit/config.toml`:
-
-        ```toml
-        [server]
-        folderWatchBlacklist = ['foldername']
+        ```
+        @st.cache(hash_funcs={%(bad_type)s: my_hash_func})
+        def my_func(...):
+            ...
         ```
 
-        ...where `foldername` is the relative or absolute path to the folder
-        where you put your virtual environment.
-
-        Otherwise, please [file a
-        bug here](https://github.com/streamlit/streamlit/issues/new/choose).
-
-        To stop this warning from showing in the meantime, try one of the
-        following:
-
-        * **Preferred:** modify your code to avoid using this type of object.
-        * Or add the argument `allow_output_mutation=True` to the `st.cache` decorator.
+        Please see the [`hash_funcs` documentation]
+        (https://streamlit.io/docs/advanced_concepts.html#advanced-caching)
+        for more details.
     """
-        % {"start": start}
+        % {"bad_type": str(bad_type).split("'")[1]}
     ).strip("\n")
 
 
@@ -325,9 +316,18 @@ class CodeHasher:
                 return _int_to_bytes(obj)
             elif isinstance(obj, list) or isinstance(obj, tuple):
                 h = hashlib.new(self.name)
-                # add type to distingush x from [x]
+
+                # Hash the name of the container so that ["a"] hashes differently from ("a",)
+                # Otherwise we'd only be hashing the data and the hashes would be the same.
                 self._update(h, type(obj).__name__.encode() + b":")
                 for e in obj:
+                    self._update(h, e, context)
+                return h.digest()
+            elif isinstance(obj, dict):
+                h = hashlib.new(self.name)
+
+                self._update(h, type(obj).__name__.encode() + b":")
+                for e in obj.items():
                     self._update(h, e, context)
                 return h.digest()
             elif obj is None:
@@ -429,21 +429,19 @@ class CodeHasher:
                 self._update(h, obj.keywords)
                 return h.digest()
             else:
-                try:
-                    # As a last resort, we pickle the object to hash it.
-                    return pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
-                except:
-                    st.warning(
-                        _hashing_error_message(
-                            "Streamlit cannot hash an object of type %s." % type(obj)
-                        )
-                    )
-        except:
-            st.warning(
-                _hashing_error_message(
-                    "Streamlit failed to hash an object of type %s." % type(obj)
-                )
-            )
+                # As a last resort
+                h = hashlib.new(self.name)
+
+                self._update(h, type(obj).__name__.encode() + b":")
+                for e in obj.__reduce__():
+                    self._update(h, e, context)
+                return h.digest()
+        except UnhashableType as e:
+            raise e
+        except Exception as e:
+            LOGGER.error(e)
+            msg = _hashing_error_message(type(obj))
+            raise UnhashableType(msg)
 
     def _code_to_bytes(self, code, context):
         h = hashlib.new(self.name)

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -20,6 +20,7 @@ import os
 import sys
 import tempfile
 import time
+import types
 import unittest
 
 import altair.vegalite.v3
@@ -30,6 +31,7 @@ import tensorflow as tf
 from mock import MagicMock
 
 import streamlit as st
+from streamlit.errors import UnhashableType
 from streamlit.util import functools_wraps
 from streamlit.hashing import NP_SIZE_LARGE, PANDAS_ROWS_LARGE, CodeHasher
 
@@ -84,6 +86,42 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash((1, 2)), get_hash((2, 2)))
         self.assertNotEqual(get_hash((1,)), get_hash(1))
         self.assertNotEqual(get_hash((1,)), get_hash([1]))
+
+    def test_dict(self):
+        dict_gen = {1: (x for x in range(1))}
+
+        self.assertEqual(get_hash({1: 1}), get_hash({1: 1}))
+        self.assertNotEqual(get_hash({1: 1}), get_hash({1: 2}))
+        self.assertNotEqual(get_hash({1: 1}), get_hash([(1, 1)]))
+
+        with self.assertRaises(UnhashableType):
+            get_hash(dict_gen)
+        get_hash(dict_gen, hash_funcs={types.GeneratorType: id})
+
+    def test_reduce_(self):
+        class A(object):
+            def __init__(self):
+                self.x = [1, 2, 3]
+
+        class B(object):
+            def __init__(self):
+                self.x = [1, 2, 3]
+
+        class C(object):
+            def __init__(self):
+                self.x = (x for x in range(1))
+
+        self.assertEqual(get_hash(A()), get_hash(A()))
+        self.assertNotEqual(get_hash(A()), get_hash(B()))
+        self.assertNotEqual(get_hash(A()), get_hash(A().__reduce__()))
+
+        with self.assertRaises(UnhashableType):
+            get_hash(C())
+        get_hash(C(), hash_funcs={types.GeneratorType: id})
+
+    def test_generator(self):
+        with self.assertRaises(UnhashableType):
+            get_hash((x for x in range(1)))
 
     def test_float(self):
         self.assertEqual(get_hash(0.1), get_hash(0.1))
@@ -190,7 +228,7 @@ class HashTest(unittest.TestCase):
         tf_session_class = type(tf_session)
 
         # Unhashable object raises an error
-        with self.assertRaises(TypeError):
+        with self.assertRaises(UnhashableType):
             get_hash(tf_session)
 
         id_hash_func = {tf_session_class: id}
@@ -664,7 +702,7 @@ class CodeHashTest(unittest.TestCase):
         # Function with unhashable object raises an error in python 3
         # In python 2 we fallback to hashing the function name
         if sys.version_info >= (3, 0):
-            with self.assertRaises(TypeError):
+            with self.assertRaises(UnhashableType):
                 get_hash(f)
 
         hash_funcs = {tf_session_class: id}


### PR DESCRIPTION
* Handle lists, tuples, dicts, objects and UnhashableType error in hashing
* Squash cache warnings and update error message

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
