### PR TITLE
Allow wider range of int-like types in NumberInput (#1087)

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -26,6 +26,7 @@ import functools
 import json
 import random
 import textwrap
+import numbers
 from datetime import datetime
 from datetime import date
 from datetime import time
@@ -2364,7 +2365,7 @@ class DeltaGenerator(object):
             else:
                 value = 0.0  # We set a float as default
 
-        int_value = isinstance(value, int)
+        int_value = isinstance(value, numbers.Integral)
         float_value = isinstance(value, float)
 
         if value is None:
@@ -2400,7 +2401,12 @@ class DeltaGenerator(object):
         args = [min_value, max_value, step]
 
         int_args = all(
-            map(lambda a: (isinstance(a, int) or isinstance(a, type(None))), args)
+            map(
+                lambda a: (
+                    isinstance(a, numbers.Integral) or isinstance(a, type(None))
+                ),
+                args,
+            )
         )
         float_args = all(
             map(lambda a: (isinstance(a, float) or isinstance(a, type(None))), args)

--- a/lib/streamlit/js_number.py
+++ b/lib/streamlit/js_number.py
@@ -19,6 +19,8 @@ from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
+import numbers
+
 
 class JSNumberBoundsException(Exception):
     pass
@@ -68,7 +70,7 @@ class JSNumber(object):
         if value_name is None:
             value_name = "value"
 
-        if not isinstance(value, int):
+        if not isinstance(value, numbers.Integral):
             raise JSNumberBoundsException("%s (%s) is not an int" % (value_name, value))
         elif value < cls.MIN_SAFE_INTEGER:
             raise JSNumberBoundsException(
@@ -100,7 +102,7 @@ class JSNumber(object):
         if value_name is None:
             value_name = "value"
 
-        if not isinstance(value, (int, float)):
+        if not isinstance(value, (numbers.Integral, float)):
             raise JSNumberBoundsException(
                 "%s (%s) is not a float" % (value_name, value)
             )


### PR DESCRIPTION
* test value integer types inclusive of numpy int64, int32, etc

* check all params as numbers.Integer (not just int)

* be more accepting of int types in JSNumber

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
