### PR TITLE
Pass --skip-lock to pipenv under pipenv-install Makefile target. (#1093)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup:
 .PHONY: pipenv-install
 pipenv-install: lib/Pipfile
 	@# Runs pipenv install; doesn't update the Pipfile.lock.
-	cd lib; pipenv install --dev
+	cd lib; pipenv install --dev --skip-lock
 
 .PHONY: pylint
 # Run "black", our Python formatter, to verify that our source files


### PR DESCRIPTION
By not passing this, we were violating the "doesn't update the
Pipfile.lock." comment on this Makefile target. I don't see where the
lockfile was later used, and so was most likely providing little
benefit.

Finally, invocation before this change took ~1m13s on my machine when
Pipfile.lock wasn't present, and ~33s when it was. With this change,
it's reliably ~17s.

The big question is if the lockfile was providing any value that I
missed picking up, so that's the major review question.

CC @tconkling

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
