### PR TITLE
Using widgetId as the key when rendering elements (#1102)

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -181,13 +181,16 @@ class Block extends PureComponent<Props> {
       reportElement.get("metadata")
     )
 
-    const isEmpty = element.get("type") === "empty"
+    const elementType = element.get("type")
+    const isEmpty = elementType === "empty"
     const enable = this.shouldComponentBeEnabled(isEmpty)
     const isStale = this.isComponentStale(enable, reportElement)
     const className = Block.getClassNames(isStale, isEmpty)
+    const simpleElement = element.get(elementType)
+    const key = simpleElement.get("id") || index
 
     return (
-      <Maybe enable={enable} key={index}>
+      <Maybe enable={enable} key={key}>
         <div className={className} style={{ width }}>
           <ErrorBoundary width={width}>
             <Suspense


### PR DESCRIPTION
* Using hash as the key

* Replacing hash with widget id

* Replacing hash with widget id

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
