### PR TITLE
st.cache expiration (#1152)

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -42,6 +42,7 @@ base58 = "*"
 blinker = "*"
 boto3 = "*"
 botocore = "*"
+cachetools = ">=4.0"
 click = ">=7.0"
 # Pin python-dateutil to work around a botocore issue: https://github.com/boto/botocore/issues/1872
 # TODO: Remove this pin when the above issue is fixed.

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -31,5 +31,5 @@ ignore_errors = True
 [mypy-streamlit.proto.*]
 ignore_errors = True
 
-[mypy-altair,base58,blinker,bokeh.embed,botocore,boto3,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas,PIL,pipenv.*,plotly.*,prometheus_client,pydeck,pyflakes,pyflakes.checker,setuptools,sympy,tensorflow.*,tornado.*,tzlocal,validators,watchdog,watchdog.observers]
+[mypy-altair,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas,PIL,pipenv.*,plotly.*,prometheus_client,pydeck,pyflakes,pyflakes.checker,setuptools,sympy,tensorflow.*,tornado.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -209,6 +209,146 @@ class CacheTest(testutil.DeltaGeneratorTestCase):
         # The other thread should not have modified the main thread
         self.assertEqual(1, get_counter())
 
+    def test_max_size(self):
+        """The oldest object should be evicted when maxsize is reached."""
+        # Create 2 cached functions to test that they don't interfere
+        # with each other.
+
+        foo_vals = []
+
+        @st.cache(max_entries=2)
+        def foo(x):
+            foo_vals.append(x)
+            return x
+
+        bar_vals = []
+
+        @st.cache(max_entries=3)
+        def bar(x):
+            bar_vals.append(x)
+            return x
+
+        self.assertEqual([], foo_vals)
+        self.assertEqual([], bar_vals)
+
+        # Stick two items in both caches. foo will be filled.
+        foo(0), foo(1)
+        bar(0), bar(1)
+        self.assertEqual([0, 1], foo_vals)
+        self.assertEqual([0, 1], bar_vals)
+
+        # 0, 1 are already cached, so called_values shouldn't change.
+        foo(0), foo(1)
+        bar(0), bar(1)
+        self.assertEqual([0, 1], foo_vals)
+        self.assertEqual([0, 1], bar_vals)
+
+        # Add a new item to the cache.
+        # foo: 0 should be evicted; 1 and 2 should be present.
+        # bar: 0, 1, 2 present.
+        foo(2)
+        bar(2)
+
+        # foo(0) again should cause 0 to be added again, since it was
+        # previously evicted. Nothing will have been evicted from bar.
+        foo(1), foo(0)
+        bar(1), bar(0)
+        self.assertEqual([0, 1, 2, 0], foo_vals)
+        self.assertEqual([0, 1, 2], bar_vals)
+
+    # Reduce the huge amount of logspam we get from hashing/caching
+    @patch("streamlit.hashing.LOGGER.debug")
+    @patch("streamlit.caching.LOGGER.debug")
+    def test_no_max_size(self, _1, _2):
+        """If max_size is None, the cache is unbounded."""
+        called_values = []
+
+        @st.cache(max_entries=None)
+        def f(x):
+            called_values.append(x)
+            return x
+
+        # Stick a bunch of items in the cache.
+        for ii in range(256):
+            f(ii)
+
+        # Clear called_values, and test that accessing the same bunch of
+        # items doesn't result in f() being called.
+        called_values = []
+        for ii in range(256):
+            f(ii)
+        self.assertEqual([], called_values)
+
+    @patch("streamlit.caching.TTLCACHE_TIMER")
+    def test_ttl(self, timer_patch):
+        """Entries should expire after the given ttl."""
+        # Create 2 cached functions to test that they don't interfere
+        # with each other.
+        foo_vals = []
+
+        @st.cache(ttl=1)
+        def foo(x):
+            foo_vals.append(x)
+            return x
+
+        bar_vals = []
+
+        @st.cache(ttl=5)
+        def bar(x):
+            bar_vals.append(x)
+            return x
+
+        # Store a value at time 0
+        timer_patch.return_value = 0
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
+
+        # Advance our timer, but not enough to expire our value.
+        timer_patch.return_value = 0.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
+
+        # Advance our timer enough to expire foo, but not bar.
+        timer_patch.return_value = 1.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0], foo_vals)
+        self.assertEqual([0], bar_vals)
+
+    def test_clear_cache(self):
+        """Clear cache should do its thing."""
+        foo_vals = []
+
+        @st.cache
+        def foo(x):
+            foo_vals.append(x)
+            return x
+
+        bar_vals = []
+
+        @st.cache
+        def bar(x):
+            bar_vals.append(x)
+            return x
+
+        foo(0), foo(1), foo(2)
+        bar(0), bar(1), bar(2)
+        self.assertEqual([0, 1, 2], foo_vals)
+        self.assertEqual([0, 1, 2], bar_vals)
+
+        # Clear the cache and access our original values again. They
+        # should be recomputed.
+        caching.clear_cache()
+
+        foo(0), foo(1), foo(2)
+        bar(0), bar(1), bar(2)
+        self.assertEqual([0, 1, 2, 0, 1, 2], foo_vals)
+        self.assertEqual([0, 1, 2, 0, 1, 2], bar_vals)
+
 
 # Temporarily turn off these tests since there's no Cache object in __init__
 # right now.

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -108,8 +108,15 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(
                 ds.signature,
                 (
-                    "(func=None, persist=False, "
-                    "allow_output_mutation=False, show_spinner=True, suppress_st_warning=False, hash_funcs=None, ignore_hash=False)"
+                    "(func=None, "
+                    "persist=False, "
+                    "allow_output_mutation=False, "
+                    "show_spinner=True, "
+                    "suppress_st_warning=False, "
+                    "hash_funcs=None, "
+                    "ignore_hash=False, "
+                    "max_entries=None, "
+                    "ttl=None)"
                 ),
             )
             self.assertTrue(ds.doc_string.startswith("Function decorator to"))


### PR DESCRIPTION
Adds `ttl` and `max_entries` params to `@st.cache`

- Each `@st.cache`d function now has its own in-memory cache (previously, all functions shared a single cache).
- `cachetools.LRUCache` and `cachetools.TTLCache` replace raw dictionaries as the cache implementations.

This closes #364. (Well, partly: per discussions with @tvst and @treuille, the other bits of that ticket (`global` and `finalizer_func` options) are going to wait for more discussion about caching changes.)

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
