### PR TITLE
1159/use_container_width (#1174)

### DIFF
--- a/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
+++ b/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
@@ -49,76 +49,88 @@ interface State {
   initialized: boolean
 }
 
+interface ViewState {
+  width: number
+  height: number
+  longitude: number
+  latitude: number
+  pitch: number
+  bearing: number
+  zoom: number
+}
+
+interface ViewPort extends ViewState {
+  mapStyle: string
+}
+
 class DeckGlChart extends React.PureComponent<PropsWithHeight, State> {
   static defaultProps = {
     height: 500,
   }
 
-  private readonly initialViewState: {
-    width: number
-    height: number
-    longitude: number
-    latitude: number
-    pitch: number
-    bearing: number
-    zoom: number
+  state = {
+    initialized: false,
   }
 
-  private readonly mapStyle: string
-  private readonly fixHexLayerBug_bound: () => void
-
-  public constructor(props: PropsWithHeight) {
-    super(props)
-
-    const specStr = this.props.element.get("spec")
-    const spec = specStr ? JSON.parse(specStr) : {}
-    const v = spec.viewport || {}
-    const { width, height } = this.props
-    this.initialViewState = {
-      width: v.width || width,
-      height: v.height || height,
-      longitude: v.longitude || 0,
-      latitude: v.latitude || 0,
-      pitch: v.pitch || 0,
-      bearing: v.bearing || 0,
-      zoom: v.zoom || 1,
-    }
-
-    this.mapStyle = getStyleUrl(v.mapStyle)
-
-    this.fixHexLayerBug_bound = this.fixHexLayerBug.bind(this)
-    this.state = { initialized: false }
-
+  componentDidMount(): void {
     // HACK: Load layers a little after loading the map, to hack around a bug
     // where HexagonLayers were not drawing on first load but did load when the
     // script got re-executed.
-    setTimeout(this.fixHexLayerBug_bound, 0)
+    this.setState({
+      initialized: true,
+    })
   }
 
-  private fixHexLayerBug(): void {
-    this.setState({ initialized: true })
+  private getViewport(): ViewPort {
+    const { element } = this.props
+
+    const specStr = element.get("spec")
+    const spec = specStr ? JSON.parse(specStr) : {}
+
+    return spec.viewport || {}
+  }
+
+  private generateViewState(viewPort: ViewPort): ViewState {
+    const { element, width, height } = this.props
+
+    const useContainerWidth = element.get("useContainerWidth")
+
+    return {
+      width: !viewPort.width || useContainerWidth ? width : viewPort.width,
+      height: viewPort.height || height,
+      longitude: viewPort.longitude || 0,
+      latitude: viewPort.latitude || 0,
+      pitch: viewPort.pitch || 0,
+      bearing: viewPort.bearing || 0,
+      zoom: viewPort.zoom || 1,
+    } as ViewState
   }
 
   public render(): JSX.Element {
+    const viewPort = this.getViewport()
+
+    const initialViewState = this.generateViewState(viewPort)
+    const mapStyle = getStyleUrl(viewPort.mapStyle)
+
     return (
       <div
         className="deckglchart stDeckGlChart"
         style={{
-          height: this.initialViewState.height,
-          width: this.initialViewState.width,
+          height: initialViewState.height,
+          width: initialViewState.width,
         }}
       >
         <DeckGL
-          initialViewState={this.initialViewState}
-          height={this.initialViewState.height}
-          width={this.initialViewState.width}
+          initialViewState={initialViewState}
+          height={initialViewState.height}
+          width={initialViewState.width}
           controller
           layers={this.state.initialized ? this.buildLayers() : []}
         >
           <StaticMap
-            height={this.initialViewState.height}
-            width={this.initialViewState.width}
-            mapStyle={this.mapStyle}
+            height={initialViewState.height}
+            width={initialViewState.width}
+            mapStyle={mapStyle}
             mapboxApiAccessToken={this.props.mapboxToken}
           />
         </DeckGL>

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -69,12 +69,10 @@ interface State {
   initialized: boolean
 }
 
-export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
-  static defaultProps = {
-    height: 500,
-  }
+export const DEFAULT_DECK_GL_HEIGHT = 500
 
-  state = {
+export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
+  readonly state = {
     initialized: false,
   }
 
@@ -87,16 +85,25 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
     })
   }
 
-  fixHexLayerBug = (): void => {
-    this.setState({ initialized: true })
-  }
-
   getDeckObject = (): DeckObject => {
     const { element, width, height } = this.props
+    const useContainerWidth = element.get("useContainerWidth")
     const json = JSON.parse(element.get("json"))
 
-    json.initialViewState.height = height
-    json.initialViewState.width = width
+    // The graph dimensions could be set from props ( like withFullscreen ) or
+    // from the generated element object
+    if (height) {
+      json.initialViewState.height = height
+      json.initialViewState.width = width
+    } else {
+      if (!json.initialViewState.height) {
+        json.initialViewState.height = DEFAULT_DECK_GL_HEIGHT
+      }
+
+      if (useContainerWidth) {
+        json.initialViewState.width = width
+      }
+    }
 
     delete json.views // We are not using views. This avoids a console warning.
 

--- a/frontend/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -56,11 +56,14 @@ class GraphVizChart extends React.PureComponent<PropsWithHeight> {
   public getChartDimensions = (): Dimensions => {
     let width = this.originalWidth
     let height = this.originalHeight
+    const useContainerWidth = this.props.element.get("useContainerWidth")
 
     if (this.props.height) {
       //fullscreen
       width = this.props.width
       height = this.props.height
+    } else if (useContainerWidth) {
+      width = this.props.width
     }
     return { width, height }
   }
@@ -107,9 +110,14 @@ class GraphVizChart extends React.PureComponent<PropsWithHeight> {
   }
 
   public render = (): React.ReactNode => {
-    const width: number = this.props.element.get("width") || this.props.width
-    const height: number =
-      this.props.element.get("height") || this.props.height
+    const elementDimensions = this.getChartDimensions()
+    const width: number = elementDimensions.width
+      ? elementDimensions.width
+      : this.props.width
+    const height: number | undefined = elementDimensions.height
+      ? elementDimensions.height
+      : this.props.height
+
     return (
       <div
         className="graphviz stGraphVizChart"

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1120,7 +1120,7 @@ class DeltaGenerator(object):
         )
 
     @_with_element
-    def graphviz_chart(self, element, figure_or_dot, width=0, height=0):
+    def graphviz_chart(self, element, figure_or_dot, width=0, height=0, use_container_width=False):
         """Display a graph using the dagre-d3 library.
 
         Parameters
@@ -1137,6 +1137,10 @@ class DeltaGenerator(object):
             Deprecated. If != 0 (default), will show an alert.
             From now on you should set the height directly in the Graphviz
             spec. Please refer to the Graphviz documentation for details.
+
+        use_container_width : bool
+            If True, set the chart width to the column width. This takes
+            precedence over the figure's native `width` value.
 
         Example
         -------
@@ -1209,7 +1213,7 @@ class DeltaGenerator(object):
                 "The `height` argument in `st.graphviz` is deprecated and will be removed on 2020-03-04"
             )
 
-        graphviz_chart.marshall(element.graphviz_chart, figure_or_dot)
+        graphviz_chart.marshall(element.graphviz_chart, figure_or_dot, use_container_width)
 
     @_with_element
     def plotly_chart(
@@ -2548,7 +2552,7 @@ class DeltaGenerator(object):
         element.empty.unused = True
 
     @_with_element
-    def map(self, element, data=None, zoom=None):
+    def map(self, element, data=None, zoom=None, use_container_width=True):
         """Display a map with points on it.
 
         This is a wrapper around st.pydeck_chart to quickly create scatterplot
@@ -2592,9 +2596,10 @@ class DeltaGenerator(object):
         import streamlit.elements.map as streamlit_map
 
         element.deck_gl_json_chart.json = streamlit_map.to_deckgl_json(data, zoom)
+        element.deck_gl_json_chart.use_container_width = use_container_width
 
     @_with_element
-    def deck_gl_chart(self, element, spec=None, **kwargs):
+    def deck_gl_chart(self, element, spec=None, use_container_width=False, **kwargs):
         """Draw a map chart using the Deck.GL library.
 
         This API closely follows Deck.GL's JavaScript API
@@ -2658,6 +2663,10 @@ class DeltaGenerator(object):
                   - Instead of "getSourceColor" : use the same as above.
                   - Instead of "getTargetColor" : use "getTargetColorR", etc.
 
+        use_container_width : bool
+            If True, set the chart width to the column width. This takes
+            precedence over the figure's native `width` value.
+
         **kwargs : any
             Same as spec, but as keywords. Keys are "unflattened" at the
             underscore characters. For example, foo_bar_baz=123 becomes
@@ -2691,25 +2700,24 @@ class DeltaGenerator(object):
            height: 530px
 
         """
-        # TODO: Add this in around 2020-01-31
-        #
-        # suppress_deprecation_warning = config.get_option(
-        #     "global.suppressDeprecationWarnings"
-        # )
-        # if not suppress_deprecation_warning:
-        #     import streamlit as st
-        #
-        #     st.warning("""
-        #         The `deck_gl_chart` widget is deprecated and will be removed on
-        #         2020-03-04. To render a map, you should use `st.pydeck_chart` widget.
-        #     """)
+
+        suppress_deprecation_warning = config.get_option(
+            "global.suppressDeprecationWarnings"
+        )
+        if not suppress_deprecation_warning:
+            import streamlit as st
+
+            st.warning("""
+                The `deck_gl_chart` widget is deprecated and will be removed on
+                2020-05-01. To render a map, you should use `st.pydeck_chart` widget.
+            """)
 
         import streamlit.elements.deck_gl as deck_gl
 
-        deck_gl.marshall(element.deck_gl_chart, spec, **kwargs)
+        deck_gl.marshall(element.deck_gl_chart, spec, use_container_width, **kwargs)
 
     @_with_element
-    def pydeck_chart(self, element, pydeck_obj=None):
+    def pydeck_chart(self, element, pydeck_obj=None, use_container_width=False):
         """Draw a chart using the PyDeck library.
 
         This supports 3D maps, point clouds, and more! More info about PyDeck
@@ -2779,7 +2787,7 @@ class DeltaGenerator(object):
         """
         import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 
-        deck_gl_json_chart.marshall(element, pydeck_obj)
+        deck_gl_json_chart.marshall(element, pydeck_obj, use_container_width)
 
     @_with_element
     def table(self, element, data=None):

--- a/lib/streamlit/elements/deck_gl.py
+++ b/lib/streamlit/elements/deck_gl.py
@@ -27,7 +27,7 @@ from streamlit.logger import get_logger
 LOGGER = get_logger(__name__)
 
 
-def marshall(proto, spec=None, **kwargs):
+def marshall(proto, spec=None, use_container_width=False, **kwargs):
     """Marshall a proto with DeckGL chart info.
 
     See DeltaGenerator.deck_gl_chart for docs.
@@ -71,3 +71,4 @@ def marshall(proto, spec=None, **kwargs):
     # Dump JSON after removing DataFrames (see loop above), because DataFrames
     # are not JSON-serializable.
     proto.spec = json.dumps(spec)
+    proto.use_container_width = use_container_width

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -20,13 +20,14 @@ import json
 EMPTY_MAP = {"initialViewState": {"latitude": 0, "longitude": 0, "pitch": 0, "zoom": 1}}
 
 
-def marshall(element, pydeck_obj):
+def marshall(element, pydeck_obj, use_container_width):
     if pydeck_obj is None:
         spec = json.dumps(EMPTY_MAP)
     else:
         spec = pydeck_obj.to_json()
 
     element.deck_gl_json_chart.json = spec
+    element.deck_gl_json_chart.use_container_width = use_container_width
 
     if pydeck_obj is not None and isinstance(pydeck_obj.deck_widget.tooltip, dict):
         element.deck_gl_json_chart.tooltip = json.dumps(pydeck_obj.deck_widget.tooltip)

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -21,7 +21,7 @@ from streamlit.logger import get_logger
 LOGGER = get_logger(__name__)
 
 
-def marshall(proto, figure_or_dot):
+def marshall(proto, figure_or_dot, use_container_width):
     """Construct a GraphViz chart object.
 
     See DeltaGenerator.graphviz_chart for docs.
@@ -35,3 +35,4 @@ def marshall(proto, figure_or_dot):
         raise Exception("Unhandled type for graphviz chart: %s" % type(figure_or_dot))
 
     proto.spec = dot
+    proto.use_container_width=use_container_width

--- a/lib/tests/streamlit/deck_gl_test.py
+++ b/lib/tests/streamlit/deck_gl_test.py
@@ -66,3 +66,10 @@ class DeckGLTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.deck_gl_chart
         self.assertEqual(c.HasField("data"), False)
         self.assertEqual(json.loads(c.spec), {})
+
+    def test_use_container_width_true(self):
+        """Test that it can be called with no args."""
+        st.deck_gl_chart(use_container_width=True)
+
+        c = self.get_delta_from_queue().new_element.deck_gl_chart
+        self.assertEqual(c.use_container_width, True)

--- a/lib/tests/streamlit/graphviz_test.py
+++ b/lib/tests/streamlit/graphviz_test.py
@@ -47,3 +47,15 @@ class GraphvizTest(testutil.DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.graphviz_chart
         self.assertEqual(hasattr(c, "spec"), True)
+
+    def test_use_container_width_true(self):
+        """Test that it can be called with use_container_width."""
+        graph = graphviz.Graph(comment="The Round Table")
+        graph.node("A", "King Arthur")
+        graph.node("B", "Sir Bedevere the Wise")
+        graph.edges(["AB"])
+
+        st.graphviz_chart(graph, use_container_width=True)
+
+        c = self.get_delta_from_queue().new_element.graphviz_chart
+        self.assertEqual(c.use_container_width, True)

--- a/proto/streamlit/proto/DeckGlChart.proto
+++ b/proto/streamlit/proto/DeckGlChart.proto
@@ -26,6 +26,9 @@ message DeckGlChart {
   string spec = 2;
 
   repeated DeckGLLayer layers = 3;
+
+  // If True, will overwrite the chart width spec to fit to container.
+  bool use_container_width = 4;
 }
 
 message DeckGLLayer {

--- a/proto/streamlit/proto/DeckGlJsonChart.proto
+++ b/proto/streamlit/proto/DeckGlJsonChart.proto
@@ -19,5 +19,9 @@ syntax = "proto3";
 message DeckGlJsonChart {
   // The dataframe that will be used as the chart's main data source.
   string json = 1;
+
   string tooltip = 2;
+
+  // If True, will overwrite the chart width spec to fit to container.
+  bool use_container_width = 4;
 }

--- a/proto/streamlit/proto/GraphVizChart.proto
+++ b/proto/streamlit/proto/GraphVizChart.proto
@@ -20,5 +20,8 @@ message GraphVizChart {
   // A specification of the GraphViz graph in the "Dot" language.
   string spec = 1;
 
+  // If True, will overwrite the chart width spec to fit to container.
+  bool use_container_width = 4;
+
   reserved 2, 3;
 }


### PR DESCRIPTION
* GraphVizChart use_container_width

* DeckGlChart
- use_container_width.
- small refactor.
- bugfix: DeckGLChart where not re-rendering if the props changes.
- adding deprecation warning message

* Fixing DeckGLJson Chart and adding use_container_width

* Solving comments from Tim

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
