### PR TITLE
Unpin python-dateutil package version (#1153)

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -41,12 +41,10 @@ astor = "*"
 base58 = "*"
 blinker = "*"
 boto3 = "*"
-botocore = "*"
+botocore = ">=1.13.44"
 cachetools = ">=4.0"
 click = ">=7.0"
-# Pin python-dateutil to work around a botocore issue: https://github.com/boto/botocore/issues/1872
-# TODO: Remove this pin when the above issue is fixed.
-python-dateutil = "<=2.8.0"
+python-dateutil = "*"
 enum-compat = "*"
 # python3 code backported to python2
 future = "*"


### PR DESCRIPTION
* Unpin python-dateutil package version

The botocore issue has been fixed and the dateutil restriction removed in https://github.com/boto/botocore/commit/95a6f8e2e1ed7d0800aada0ab17c1dba15dbed57. Commit available in botocore>=1.13.44

* Add min requirement for botocore

This is the minimum version that has the dateutil fix

Co-authored-by: Thiago Teixeira <thiago@streamlit.io>

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
